### PR TITLE
Lower cabal bounds for GHC 7.10.3 / stackage LTS 6.35.

### DIFF
--- a/configurator-pg.cabal
+++ b/configurator-pg.cabal
@@ -30,12 +30,14 @@ library
                        Data.Configurator.Parser
                        Data.Configurator.Syntax
                        Data.Configurator.Types
-  build-depends:       base                 >= 4.9.1 && < 4.13
+  build-depends:       base                 >= 4.8.2 && < 4.13
                      , attoparsec           >= 0.13.1 && < 0.14
-                     , containers           >= 0.5.7.1 && < 0.7
+                     , containers           >= 0.5.6.2 && < 0.7
                      , protolude            >= 0.1.10 && < 0.3
-                     , scientific           >= 0.3.5.2 && < 0.4
+                     , scientific           >= 0.3.4.9 && < 0.4
                      , text                 >= 1.2.2.2 && < 1.3
+  if impl(ghc < 8)
+    build-depends:     transformers         >= 0.4.2 && < 0.5
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings, NoImplicitPrelude
@@ -45,11 +47,11 @@ test-suite tests
   type:                exitcode-stdio-1.0
   main-is:             Test.hs
   hs-source-dirs:      tests
-  build-depends:       base                 >= 4.9.1 && < 4.13
+  build-depends:       base                 >= 4.8.2 && < 4.13
                      , configurator-pg
-                     , HUnit                >= 1.5 && < 1.7
-                     , bytestring           >= 0.10.8.1 && < 0.11
-                     , filepath             >= 1.4.1.1 && < 1.5
+                     , HUnit                >= 1.3.1.2 && < 1.7
+                     , bytestring           >= 0.10.6 && < 0.11
+                     , filepath             >= 1.4 && < 1.5
                      , protolude            >= 0.1.10 && < 0.3
                      , test-framework       >= 0.8.1.1 && < 0.9
                      , test-framework-hunit >= 0.3.0.2 && < 0.4


### PR DESCRIPTION
This lowers bounds and adds dependencies to work with GHC 7.10.

I'd rather avoid the `if impl` thing though, but leaving it here to merge on demand now that I've figured it out.