### PR TITLE
bump travis GHC versions: include cabal GHC 8.10, and update stack to GHC 8.8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,10 @@ matrix:
   - ghc: 8.4.4
   - ghc: 8.6.5
   - ghc: 8.8.3
+  - ghc: 8.10.1
 
   # Stack
-  - ghc: 8.8.2
+  - ghc: 8.8.3
     env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
   include:
 
   # Cabal
-  - ghc: 7.10.3
   - ghc: 8.0.2
   - ghc: 8.2.2
   - ghc: 8.4.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,14 @@ matrix:
   - ghc: 8.4.4
   - ghc: 8.6.5
   - ghc: 8.8.3
-  - ghc: 8.10.1
 
   # Stack
   - ghc: 8.8.3
     env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
+
+  allow-failures:
+  # until protolude 0.3 is released
+  - ghc: 8.10.1
 
 install:
   - |

--- a/configurator-pg.cabal
+++ b/configurator-pg.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.12
 name:                configurator-pg
-version:             0.2.2
+version:             0.2.3
 synopsis:            Reduced parser for configurator-ng config files
 description:
   This module provides a simplified and updated interface to the
@@ -33,15 +33,12 @@ library
                        Data.Configurator.Parser
                        Data.Configurator.Syntax
                        Data.Configurator.Types
-  build-depends:       base                 >= 4.8.2 && < 4.15
+  build-depends:       base                 >= 4.9 && < 4.15
                      , megaparsec           >= 7.0.0 && < 8.1
                      , containers           >= 0.5.6.2 && < 0.7
                      , protolude            >= 0.1.10 && < 0.4
                      , scientific           >= 0.3.4.9 && < 0.4
                      , text                 >= 1.2.2.2 && < 1.3
-  if impl(ghc < 8)
-    build-depends:     fail                 >= 4.9 && < 5
-                     , transformers         >= 0.4.2 && < 0.5
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings, NoImplicitPrelude
@@ -51,7 +48,7 @@ test-suite tests
   type:                exitcode-stdio-1.0
   main-is:             Test.hs
   hs-source-dirs:      tests
-  build-depends:       base                 >= 4.8.2 && < 4.15
+  build-depends:       base                 >= 4.9 && < 4.15
                      , configurator-pg
                      , HUnit                >= 1.3.1.2 && < 1.7
                      , bytestring           >= 0.10.6 && < 0.11

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.2
+resolver: lts-15.7


### PR DESCRIPTION
Expect the GHC 8.10 build to break currently because protolude 0.3 hasn't made it to hackage.