### PR TITLE
prepare for GHC 9.2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+packages: .
+
+source-repository-package
+  type: git
+  location: https://github.com/protolude/protolude.git
+  tag: 3e249724fd0ead27370c8c297b1ecd38f92cbd5b

--- a/configurator-pg.cabal
+++ b/configurator-pg.cabal
@@ -33,7 +33,7 @@ library
                        Data.Configurator.Parser
                        Data.Configurator.Syntax
                        Data.Configurator.Types
-  build-depends:       base                 >= 4.9 && < 4.15
+  build-depends:       base                 >= 4.9 && < 4.17
                      , megaparsec           >= 7.0.0 && < 9.3
                      , containers           >= 0.5.6.2 && < 0.7
                      , protolude            >= 0.1.10 && < 0.4
@@ -48,7 +48,7 @@ test-suite tests
   type:                exitcode-stdio-1.0
   main-is:             Test.hs
   hs-source-dirs:      tests
-  build-depends:       base                 >= 4.9 && < 4.15
+  build-depends:       base                 >= 4.9 && < 4.17
                      , configurator-pg
                      , HUnit                >= 1.3.1.2 && < 1.7
                      , bytestring           >= 0.10.6 && < 0.12

--- a/configurator-pg.cabal
+++ b/configurator-pg.cabal
@@ -34,7 +34,7 @@ library
                        Data.Configurator.Syntax
                        Data.Configurator.Types
   build-depends:       base                 >= 4.9 && < 4.15
-                     , megaparsec           >= 7.0.0 && < 9.2
+                     , megaparsec           >= 7.0.0 && < 9.3
                      , containers           >= 0.5.6.2 && < 0.7
                      , protolude            >= 0.1.10 && < 0.4
                      , scientific           >= 0.3.4.9 && < 0.4


### PR DESCRIPTION
Builds against GHC 9.2 with the unreleased protolude 0.3.1.