### PR TITLE
Allow megaparsec 9.6

### DIFF
--- a/configurator-pg.cabal
+++ b/configurator-pg.cabal
@@ -34,7 +34,7 @@ library
                        Data.Configurator.Syntax
                        Data.Configurator.Types
   build-depends:       base                 >= 4.9 && < 4.20
-                     , megaparsec           >= 7.0.0 && < 9.6
+                     , megaparsec           >= 7.0.0 && < 9.7
                      , containers           >= 0.5.6.2 && < 0.7
                      , protolude            >= 0.1.10 && < 0.4
                      , scientific           >= 0.3.4.9 && < 0.4

--- a/configurator-pg.cabal
+++ b/configurator-pg.cabal
@@ -51,7 +51,6 @@ test-suite tests
   build-depends:       base                 >= 4.9 && < 4.20
                      , configurator-pg
                      , HUnit                >= 1.3.1.2 && < 1.7
-                     , bytestring           >= 0.10.6 && < 0.12
                      , filepath             >= 1.4 && < 1.5
                      , protolude            >= 0.1.10 && < 0.4
                      , test-framework       >= 0.8.1.1 && < 0.9


### PR DESCRIPTION
I'm currently trying to build PostgREST with GHC 9.8.1 - this is the last dependency remaining to make this work, I think.